### PR TITLE
Add link to virtual session to talk template

### DIFF
--- a/src/pretalx/agenda/templates/agenda/talk.html
+++ b/src/pretalx/agenda/templates/agenda/talk.html
@@ -87,6 +87,9 @@
                     <em>{{ phrases.agenda.schedule.do_not_record }}</em>
                 {% endif %}
             </small>
+            <button style="background-color: #2879c0;margin-top: 1em;">
+                <a href="https://seagl.org/attend" style="color: white;">Click here to attend the virtual conference</a>
+            </button>
         </h3>
         <div class="talk row">
             <div class="talk-content">


### PR DESCRIPTION
Changes the session template so that it includes a link to the attend page for attendees to attend virtually

## How has this been tested?
NOT TESTED!!

## Checklist

<!--- Put an `x` in the boxes that apply. -->
<!--- It is ok to not check all boxes! We just want to know if we need to do any work after merging the PR. -->

- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation.
- [ ] My change is listed in the ``doc/changelog.rst``.
